### PR TITLE
Use getNativeDependencyTypeClass to grab the dependency type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ nativeUtils {
   }
 
   nativeDependencyContainer {
-    libgrapplefrcdriver(edu.wpi.first.nativeutils.dependencies.WPISharedMavenDependency) {
+    libgrapplefrcdriver(getNativeDependencyTypeClass('WPISharedMavenDependency')) {
       version = "2023.0.0-beta4"
       groupId = "au.grapplerobotics"
       artifactId = "libgrapplefrcdriver"


### PR DESCRIPTION
There are some cases (mainly subprojects) where the full classpath isn't imported, causing the current method to not work. getThingTypeClass is our trick used in multiple places to solve this issue.

Also digging through, I definitely want to see what I can do to make getting the libraries into rust easier. That is definitely not how I expected that to be done, but I realized I don't have a good method to do that anyway.  https://github.com/wpilibsuite/native-utils/issues/186